### PR TITLE
Variable Speed and Time Indicators. Version 1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This extension will display a list of your latest downloads in the Firefox sidebar.
 
-The latest version is **0.6**
+The latest version is **1.0**
 
 ## How do I use this?
 
@@ -39,6 +39,7 @@ There is also a browser toolbar button which opens the Downloads sidebar.
   * approximate time remaining for a download
   * updated icons
   * UI adjustments so the extension better fits with the Firefox design guidelines
+  * variable speed and time indicators
   * various fixes
 
 ### Requested features

--- a/sidebar/panel.js
+++ b/sidebar/panel.js
@@ -177,10 +177,7 @@ function start() {
       const parsedUrl = new URL(item.url);
       const hostname = parsedUrl.hostname || parsedUrl.href;
       const size = this.getFileSizeString(item.bytesReceived);
-      const date = new Date(item.startTime);
-      const localeDate = date.toLocaleDateString();
-      const localeTime = date.toLocaleTimeString();
-      const dateTime = `${localeDate} ${localeTime}`;
+      const dateTime = this.getDateTime(item);
       const stateButtonText = this.getStateButtonText(item.state);
       const percentage = item.bytesReceived / item.totalBytes;
 
@@ -204,6 +201,17 @@ function start() {
         remainingTime,
         currentSpeed,
       };
+    },
+
+    getDateTime(item) {
+      const date = new Date(item.startTime);
+      if (date.getTime() === 0) {
+        return "Unknown"; //epoch case
+      }
+
+      const localeDate = date.toLocaleDateString();
+      const localeTime = date.toLocaleTimeString();
+      return `${localeDate} ${localeTime}`;
     },
 
     prepareItems(items) {
@@ -484,10 +492,7 @@ function start() {
       this.set(`${keypath}.currentSpeed`, currentSpeed);
       
       if (downloadInProgress) {
-        const date = new Date(item.startTime);
-        const localeDate = date.toLocaleDateString();
-        const localeTime = date.toLocaleTimeString();
-        const dateTime = `${localeDate} ${localeTime}`;
+        const dateTime = this.getDateTime(item);
         this.set(`${keypath}.dateTime`, dateTime);
       }
 

--- a/sidebar/panel.js
+++ b/sidebar/panel.js
@@ -482,6 +482,14 @@ function start() {
       this.set(`${keypath}.folderClass`, folderClass);
       this.set(`${keypath}.remainingTime`, remainingTime);
       this.set(`${keypath}.currentSpeed`, currentSpeed);
+      
+      if (downloadInProgress) {
+        const date = new Date(item.startTime);
+        const localeDate = date.toLocaleDateString();
+        const localeTime = date.toLocaleTimeString();
+        const dateTime = `${localeDate} ${localeTime}`;
+        this.set(`${keypath}.dateTime`, dateTime);
+      }
 
       if (downloadState !== IN_PROGRESS) {
         this.removeFromActiveDownloads(item.id);

--- a/sidebar/panel.js
+++ b/sidebar/panel.js
@@ -399,7 +399,6 @@ function start() {
       const errored = !!this.interrupts[item.error];
       const resumable = item.paused && item.canResume;
       const canceled = (item.error === this.interrupts.USER_CANCELED);
-      const in_progress = (item.state === IN_PROGRESS);
       const complete = (item.state === COMPLETE);
 
       if (errored) {
@@ -535,8 +534,9 @@ function start() {
     },
 
     getCurrentSpeed(item) {
+      const { PAUSED, COMPLETE } = this.states;
       const downloadState = this.calculateDownloadState(item);
-      if (downloadState === PAUSED) {
+      if (downloadState === PAUSED || downloadState === COMPLETE) {
         return "0";
       }
 
@@ -567,9 +567,12 @@ function start() {
     },
 
     getRemainingTimeString(item) {
+      const { PAUSED, COMPLETE } = this.states;
       const downloadState = this.calculateDownloadState(item);
       if (downloadState === PAUSED) {
         return "Paused";
+      } else if (downloadState === COMPLETE) {
+        return "Completed";
       }
 
       const remainingSeconds = this.getRemainingSeconds(item);

--- a/sidebar/panel.js
+++ b/sidebar/panel.js
@@ -588,20 +588,30 @@ function start() {
       }
 
       const remainingSeconds = this.getRemainingSeconds(item);
-      const prefixSeparator = "- ";
 
-      //this is quite ad-hoc, but it is the best possible solution
-      if (remainingSeconds > DAY_INT) {
+      if (isNaN(remainingSeconds) || remainingSeconds <= SECOND_INT) {
+        return "";
+      } else if (remainingSeconds > DAY_INT) {
         return "Over a day remaining";
-      } else if (remainingSeconds > HOUR_INT) {
-        return prefixSeparator + this.divideAndRound(remainingSeconds, HOUR_INT) + " hours remaining";
-      } else if (remainingSeconds > MINUTE_INT) {
-        return prefixSeparator + this.divideAndRound(remainingSeconds, MINUTE_INT) + " minutes remaining";
-      } else if (remainingSeconds > SECOND_INT) {
-        return prefixSeparator + this.divideAndRound(remainingSeconds, SECOND_INT) + " seconds remaining";
       }
 
-      return "";
+      const prefixSeparator = "- ";
+      let timeUnit = 0;
+      let suffix = '';
+
+      if (remainingSeconds > HOUR_INT) {
+        timeUnit = HOUR_INT;
+        suffix = " hours remaining";
+      } else if (remainingSeconds > MINUTE_INT) {
+        timeUnit = MINUTE_INT;
+        suffix = " minutes remaining";
+      } else
+      {
+        timeUnit = SECOND_INT;
+        suffix = " seconds remaining";
+      }
+      const remaining = this.divideAndRound(remainingSeconds, timeUnit);
+      return `${prefixSeparator}${remaining}${suffix}`;
     },
 
     divideAndRound(unit, divide) {

--- a/sidebar/panel.js
+++ b/sidebar/panel.js
@@ -601,14 +601,14 @@ function start() {
 
       if (remainingSeconds > HOUR_INT) {
         timeUnit = HOUR_INT;
-        suffix = " hours remaining";
+        suffix = "h remaining";
       } else if (remainingSeconds > MINUTE_INT) {
         timeUnit = MINUTE_INT;
-        suffix = " minutes remaining";
+        suffix = "m remaining";
       } else
       {
         timeUnit = SECOND_INT;
-        suffix = " seconds remaining";
+        suffix = "s remaining";
       }
       const remaining = this.divideAndRound(remainingSeconds, timeUnit);
       return `${prefixSeparator}${remaining}${suffix}`;

--- a/sidebar/panel.js
+++ b/sidebar/panel.js
@@ -366,7 +366,6 @@ function start() {
 
     addItem(data) {
       const item = this.prepareItem(data);
-      const fileName = this.getFilename(item.filename);
 
       this.unshift(ITEMS, item);
 

--- a/sidebar/template-item.html
+++ b/sidebar/template-item.html
@@ -25,7 +25,7 @@
       <input id="link-{{id}}" class="item-link-input" value="{{url}}" />
     </div>
 
-    <span class="item-datetime">{{dateTime}}</span>
+    <span class="item-datetime">Start: {{dateTime}}</span>
     <span class="item-speed">{{currentSpeed}} {{remainingTime}}</span>
 
     <div class="item-options">

--- a/sidebar/template-item.html
+++ b/sidebar/template-item.html
@@ -26,7 +26,7 @@
     </div>
 
     <span class="item-datetime">{{dateTime}}</span>
-    <span class="item-speed">{{currentSpeed}} MB/s - {{remainingMinutes}}</span>
+    <span class="item-speed">{{currentSpeed}} {{remainingTime}}</span>
 
     <div class="item-options">
       <div class="progress" title="{{percentage}}%">


### PR DESCRIPTION
Hello again!

I've got a new pull request with a few improvements. This time I've updated the plugin so it reports remaining time in minutes, seconds, hours and over a day of remaining time.

I've also updated the speed measurements so it checks for KB/s, MB/s, GB/s.

Some other sanity/clarity checks have been added. I propose (and add in the pull request) the version of the extension to bump to 1.0. I believe the extension to be stable enough and updated enough that the bump version is justified, it is not like the extension is unstable or in beta.

Let me know what you think!