### PR TITLE
Fix handle failed state, folder state, and prefix separator on over a day

### DIFF
--- a/sidebar/panel.js
+++ b/sidebar/panel.js
@@ -531,21 +531,12 @@ function start() {
     },
 
     getFolderClass(state) {
-      return "folderEnabled";
       /*
-      In the past we had this code checking the state
-      of the download. It looks like the application is better
-      if we always report a folderEnabled state.
-
-      This code is here in case this behaviour wants to be
-      changed in the future.
-      
-      const { COMPLETE } = this.states;
-      if (state === COMPLETE) {
-        return "folderEnabled";
-      }
-      return "folderDisabled";
+      In the past we had this function check the state
+      of the download and apply different styles.
+      The possible styles are folderEnabled and folderDisabled.
       */
+      return "folderEnabled";
     },
 
     getLimitedUrl(url) {

--- a/sidebar/panel.js
+++ b/sidebar/panel.js
@@ -531,11 +531,21 @@ function start() {
     },
 
     getFolderClass(state) {
+      return "folderEnabled";
+      /*
+      In the past we had this code checking the state
+      of the download. It looks like the application is better
+      if we always report a folderEnabled state.
+
+      This code is here in case this behaviour wants to be
+      changed in the future.
+      
       const { COMPLETE } = this.states;
       if (state === COMPLETE) {
         return "folderEnabled";
       }
       return "folderDisabled";
+      */
     },
 
     getLimitedUrl(url) {
@@ -546,10 +556,14 @@ function start() {
     },
 
     getCurrentSpeed(item) {
-      const { PAUSED, COMPLETE } = this.states;
+      const { PAUSED, COMPLETE, FAILED } = this.states;
       const downloadState = this.calculateDownloadState(item);
-      if (downloadState === PAUSED || downloadState === COMPLETE) {
-        return "0";
+      if (downloadState === PAUSED) {
+        return "Paused";
+      } else if (downloadState === COMPLETE) {
+        return "Completed";
+      } else if (downloadState === FAILED) {
+        return "Failed";
       }
 
       const remainingSeconds = this.getRemainingSeconds(item);
@@ -579,12 +593,12 @@ function start() {
     },
 
     getRemainingTimeString(item) {
-      const { PAUSED, COMPLETE } = this.states;
+      const { PAUSED, COMPLETE, FAILED } = this.states;
       const downloadState = this.calculateDownloadState(item);
-      if (downloadState === PAUSED) {
-        return "Paused";
-      } else if (downloadState === COMPLETE) {
-        return "Completed";
+      if (downloadState === PAUSED   ||
+          downloadState === COMPLETE ||
+          downloadState === FAILED) {
+        return "";
       }
 
       const remainingSeconds = this.getRemainingSeconds(item);

--- a/sidebar/panel.js
+++ b/sidebar/panel.js
@@ -602,14 +602,14 @@ function start() {
       }
 
       const remainingSeconds = this.getRemainingSeconds(item);
+      const prefixSeparator = "- ";
 
       if (isNaN(remainingSeconds) || remainingSeconds <= SECOND_INT) {
         return "";
       } else if (remainingSeconds > DAY_INT) {
-        return "Over a day remaining";
+        return `${prefixSeparator} Over a day remaining`;
       }
 
-      const prefixSeparator = "- ";
       let timeUnit = 0;
       let suffix = '';
 


### PR DESCRIPTION
Like the title says, this should close #15 and #16 and another inconsistency I've found while checking the code.

This PR doesn't include a version bump.

I would also like to discuss if the code on getFolderClass that is commented should be removed, it feels weird leaving the code without it and an explanation.